### PR TITLE
fix: install script version handling and development flags

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "cel"
-version: "3.0.1"
+version: "3.0.2"
 usage: "Validate Helm values using CEL expressions"
 description: |-
   A Helm plugin to validate values.yaml using CEL expressions defined in values.cel.yaml.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -81,7 +81,10 @@ echo "ARCHIVE: ${ARCHIVE}"
 if [ -n "$HELM_CEL_PLUGIN_DIR" ]; then
   # Development mode: DIR override
   echo "Development mode: overrinding DIR with ${HELM_CEL_PLUGIN_DIR}."
-  HELM_PLUGIN_DIR="$HELM_CEL_PLUGIN_DIR"
+  HELM_PLUGIN_DIR="$HELM_CEL_PLUGIN_DIR"  
+fi
+if [ -z "$HELM_PLUGIN_DIR" ]; then
+  HELM_PLUGIN_DIR="${HELM_PLUGIN_HOME:-$HOME/.local/share/helm/plugins}/helm-cel"
 fi
 echo "DIR:     ${HELM_PLUGIN_DIR}"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,61 +3,90 @@ set -e
 
 # Development mode: skip download if env var is set
 if [ -n "$HELM_CEL_PLUGIN_NO_INSTALL_HOOK" ]; then
-    echo "Development mode: not downloading versioned release."
-    exit 0
+  echo "Development mode: not downloading versioned release."
+  exit 0
 fi
 
-# Get version from plugin.yaml (assumes version: "x.y.z" is present)
-VERSION=$(grep '^version:' plugin.yaml | cut -d '"' -f 2)
+if [ -n "$HELM_CEL_PLUGIN_VERSION" ]; then
+  # Development mode: version override
+  echo "Development mode: overrinding VERSION with ${HELM_CEL_PLUGIN_VERSION}."
+  VERSION="$HELM_CEL_PLUGIN_VERSION"
+else
+  # Get version from plugin.yaml (assumes version: "x.y.z" is present)
+  VERSION=$(grep '^version:' plugin.yaml | cut -d '"' -f 2)
+fi
+echo "VERSION: ${VERSION}"
 
-# Detect OS
-OS=""
-case "$(uname -s)" in
-    Darwin)
-        OS="Darwin"
-        ;;
-    Linux)
-        OS="Linux"
-        ;;
-    MINGW*|MSYS*|CYGWIN*|Windows_NT)
-        OS="Windows"
-        ;;
-    *)
-        echo "Unsupported OS: $(uname -s)"
-        exit 1
-        ;;
-esac
+if [ -n "$HELM_CEL_PLUGIN_OS" ]; then
+  # Development mode: OS override
+  echo "Development mode: overrinding OS with ${HELM_CEL_PLUGIN_OS}."
+  OS="$HELM_CEL_PLUGIN_OS"
+else
+  # Detect OS
+  OS=""
+  case "$(uname -s)" in
+  Darwin)
+    OS="Darwin"
+    ;;
+  Linux)
+    OS="Linux"
+    ;;
+  MINGW* | MSYS* | CYGWIN* | Windows_NT)
+    OS="Windows"
+    ;;
+  *)
+    echo "Unsupported OS: $(uname -s)"
+    exit 1
+    ;;
+  esac
+fi
+echo "OS:      ${OS}"
 
-# Detect ARCH
-ARCH=""
-case "$(uname -m)" in
-    x86_64)
-        ARCH="amd64"
-        ;;
-    aarch64|arm64)
-        ARCH="arm64"
-        ;;
-    armv6*)
-        ARCH="armv6"
-        ;;
-    armv7*)
-        ARCH="armv7"
-        ;;
-    *)
-        echo "Failed to detect target architecture: $(uname -m)"
-        exit 1
-        ;;
-esac
+if [ -n "$HELM_CEL_PLUGIN_ARCH" ]; then
+  # Development mode: ARCH override
+  echo "Development mode: overrinding ARCH with ${HELM_CEL_PLUGIN_ARCH}."
+  ARCH="$HELM_CEL_PLUGIN_ARCH"
+else
+  # Detect ARCH
+  ARCH=""
+  case "$(uname -m)" in
+  x86_64)
+    ARCH="x86_64"
+    ;;
+  aarch64 | arm64)
+    ARCH="arm64"
+    ;;
+  armv6*)
+    ARCH="armv6"
+    ;;
+  armv7*)
+    ARCH="armv7"
+    ;;
+  *)
+    echo "Failed to detect target architecture: $(uname -m)"
+    exit 1
+    ;;
+  esac
+fi
+echo "ARCH:    ${ARCH}"
 
 ARCHIVE="helm-cel_${VERSION}_${OS}_${ARCH}"
 if [ "$OS" = "Windows" ]; then
-    ARCHIVE="${ARCHIVE}.zip"
+  ARCHIVE="${ARCHIVE}.zip"
 else
-    ARCHIVE="${ARCHIVE}.tar.gz"
+  ARCHIVE="${ARCHIVE}.tar.gz"
 fi
+echo "ARCHIVE: ${ARCHIVE}"
+
+if [ -n "$HELM_CEL_PLUGIN_DIR" ]; then
+  # Development mode: DIR override
+  echo "Development mode: overrinding DIR with ${HELM_CEL_PLUGIN_DIR}."
+  HELM_PLUGIN_DIR="$HELM_CEL_PLUGIN_DIR"
+fi
+echo "DIR:     ${HELM_PLUGIN_DIR}"
 
 URL="https://github.com/idsulik/helm-cel/releases/download/v${VERSION}/${ARCHIVE}"
-echo "Downloading $URL"
+echo "URL:     ${URL}"
 
 # Clean and create bin directory
 rm -rf "$HELM_PLUGIN_DIR/bin"


### PR DESCRIPTION
After the last update I realized I got an automatic upgrade, even when using the `helm plugin install` with `--version` flag, as follows:

---

<img width="871" height="75" alt="image" src="https://github.com/user-attachments/assets/7725a405-b626-44b4-8735-aa02c7d4e033" />

---

I looked up the code and realized the installation script has changed for better. So i tried to make different installations using just the latest 2 versions to make sure the newer versions were working, as follows:

---

<img width="862" height="122" alt="image" src="https://github.com/user-attachments/assets/e82bf0c8-4813-46a1-8664-15da2a9ff06d" />

---

<img width="868" height="68" alt="image" src="https://github.com/user-attachments/assets/6d611a0e-41e9-40d6-ab3d-cb5e5c5a5719" />

---

Since when trying to install `3.0.1` I got an error and when trying to install `3.0.0` I actually got `3.0.1`, I debugged further. Looking closer I have discovered that it detects my ARCH as `x86_64` and the installation script looks for a file with `amd64` because (of this)[https://github.com/idsulik/helm-cel/blob/v3.0.1/scripts/install.sh#L34-L35], however, the release files do use `x86_64` as the arch specifier, so it does not need to be changed when building the download url.

---

<img width="1597" height="984" alt="image" src="https://github.com/user-attachments/assets/dc021efa-bee2-4d26-885d-01d44dc0242b" />

---

So I made this PR to try to give a contribution with this tool which have been very useful in my company. Great job, by the way. I have, then:
- Fixed the ARCH specifier when building the url;
- Added some "echoes" in the install script to help us now what is going on;
- Added some development override environment variables to make local testing easier and cover more scenarios.

What do you think?